### PR TITLE
Start at row 1 when scanning for keys/sections

### DIFF
--- a/convert.php
+++ b/convert.php
@@ -58,7 +58,7 @@ function buildSectionKeysArray(&$sheet, &$languages)
 {
 	$keys = array();
 	$x = 0;
-	$y = 3;
+	$y = 1;
 	$count = 0;
 
 	$section_name = NULL;

--- a/convert_excel_json.php
+++ b/convert_excel_json.php
@@ -44,7 +44,7 @@ function buildSectionKeysArray(&$sheet, &$languages)
 {
 	$keys = array();
 	$x = 0;
-	$y = 3;
+	$y = 1;
 	$count = 0;
 
 	$section_name = NULL;
@@ -65,7 +65,7 @@ function buildSectionKeysArray(&$sheet, &$languages)
 			}
 			else if($section_name != NULL)
 			{
-				//printf("\tKey: %s\n", $cell_info->value);
+				printf("\tKey: %s\n", $cell_info->value);
 				$keys[$section_name][] = array('key' => $cell_info->value, 'row' => $y);
 			}
 			//var_dump($cell_info);

--- a/convert_json_excel.php
+++ b/convert_json_excel.php
@@ -44,7 +44,7 @@ function buildSectionKeysArray(&$sheet, &$languages)
 {
 	$keys = array();
 	$x = 0;
-	$y = 3;
+	$y = 1;
 	$count = 0;
 
 	$section_name = NULL;


### PR DESCRIPTION
When converting to Excel and converting back to JSON, the first section was always missing.